### PR TITLE
그룹 찾기 -> 댓글 기능 수정

### DIFF
--- a/src/main/java/ams/group/controller/GroupCommentController.java
+++ b/src/main/java/ams/group/controller/GroupCommentController.java
@@ -36,14 +36,42 @@ public class GroupCommentController {
 	@ResponseBody
 	@RequestMapping(value="/create", method = RequestMethod.POST)
 	public void create(@RequestBody GroupCommentVO vo){
-		System.out.println("get create.........");
+		System.out.println("post create.........");
 		try {
 			service.createComment(vo);
 		} catch(Exception e) {
 			e.printStackTrace();
 		}
 	}
-	@RequestMapping(value="/list")
+	
+	@ResponseBody
+	@RequestMapping(value="/count", method = RequestMethod.POST)
+	public int count(@RequestBody String groupId){
+		System.out.println("post count.........");
+		int ret=0;
+		try {
+			ret=service.commentCount(Integer.parseInt(groupId));
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+		return ret;
+	}
+	
+	@ResponseBody
+	@RequestMapping(value="/currentCount", method = RequestMethod.POST)
+	public int currentCount(@RequestBody GroupCommentVO vo){
+		System.out.println("post currentCount.........");
+		int ret=0;
+		try {
+			ret=service.currentCommentCount(vo);
+			System.out.println("ret: "+ret);
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+		return ret;
+	}
+	
+	@RequestMapping(value="/list", method = RequestMethod.GET)
 	public ModelAndView list(@RequestParam int groupId, @RequestParam(defaultValue="1") int curPage, ModelAndView mav, Principal principal) throws JsonProcessingException {
 		try {
 			GroupCriteria cri = new GroupCriteria();
@@ -64,7 +92,7 @@ public class GroupCommentController {
 		return mav;
 	}
 	@ResponseBody
-	@RequestMapping("delete")
+	@RequestMapping(value="delete" ,method = RequestMethod.DELETE)
 	public int delete(@RequestBody GroupCommentVO vo) {
 		System.out.println("get delete.........");
 		int ret=0;
@@ -76,7 +104,7 @@ public class GroupCommentController {
 		return ret;
 	}
 	@ResponseBody
-	@RequestMapping("update")
+	@RequestMapping(value="update", method = {RequestMethod.PUT, RequestMethod.PATCH})
 	public int update(@RequestBody GroupCommentVO vo) {
 		System.out.println("get update.........");
 		int ret=0;
@@ -87,4 +115,5 @@ public class GroupCommentController {
 		}
 		return ret;
 	}
+	
 }

--- a/src/main/java/ams/group/dao/GroupCommentDAO.java
+++ b/src/main/java/ams/group/dao/GroupCommentDAO.java
@@ -12,4 +12,5 @@ public interface GroupCommentDAO {
 		public int deleteComment(GroupCommentVO vo)throws Exception;
 		public List<GroupCommentVO> commentList(int groupId, GroupCriteria cri)throws Exception;
 		public int commentCount(int groupId)throws Exception;
+		public int currentCommentCount(GroupCommentVO vo)throws Exception;
 }

--- a/src/main/java/ams/group/dao/GroupCommentDAOImpl.java
+++ b/src/main/java/ams/group/dao/GroupCommentDAOImpl.java
@@ -42,4 +42,8 @@ public class GroupCommentDAOImpl implements GroupCommentDAO {
 	public int commentCount(int groupId) throws Exception {
 		return sql.selectOne(ns+".commentCount", groupId);
 	}
+	@Override
+	public int currentCommentCount(GroupCommentVO vo)throws Exception{
+		return sql.selectOne(ns+".currentCommentCount", vo);
+	}
 }

--- a/src/main/java/ams/group/dao/GroupDAO.java
+++ b/src/main/java/ams/group/dao/GroupDAO.java
@@ -23,8 +23,8 @@ public interface GroupDAO {
 	public int createSchedule(GroupScheduleVO vo) throws Exception;
 	public int modifySchedule(GroupScheduleVO vo) throws Exception;
 	public int deleteSchedule(int scheduleId) throws Exception;
-	public List<GroupScheduleVO> getScheduleList(int groupId) throws Exception; //일정 관리 시 스케줄 리스트 얻기 
-	public GroupScheduleVO getSchedule(GroupScheduleVO vo) throws Exception; //출석 시 해당 스케줄 얻기 
+	public List<GroupScheduleVO> getScheduleList(int groupId) throws Exception; //�씪�젙 愿�由� �떆 �뒪耳�以� 由ъ뒪�듃 �뼸湲� 
+	public GroupScheduleVO getSchedule(GroupScheduleVO vo) throws Exception; //異쒖꽍 �떆 �빐�떦 �뒪耳�以� �뼸湲� 
 	public int requestAttend(GroupAttendanceVO vo) throws Exception;
 	public int addDemerit(GroupMemberVO vo) throws Exception;
 	public String chkAttendanceStatus(GroupAttendanceVO vo) throws Exception;

--- a/src/main/java/ams/group/service/GroupCommentService.java
+++ b/src/main/java/ams/group/service/GroupCommentService.java
@@ -12,4 +12,5 @@ public interface GroupCommentService {
 		public int deleteComment(GroupCommentVO vo)throws Exception;
 		public List<GroupCommentVO> commentList(int groupId, GroupCriteria cri)throws Exception;
 		public int commentCount(int groupId)throws Exception;
+		public int currentCommentCount(GroupCommentVO vo)throws Exception;
 }

--- a/src/main/java/ams/group/service/GroupCommentServiceImpl.java
+++ b/src/main/java/ams/group/service/GroupCommentServiceImpl.java
@@ -41,4 +41,8 @@ public class GroupCommentServiceImpl implements GroupCommentService {
 	public int commentCount(int groupId) throws Exception {
 		return dao.commentCount(groupId);
 	}
+	@Override
+	public int currentCommentCount(GroupCommentVO vo)throws Exception{
+		return dao.currentCommentCount(vo);
+	}
 }

--- a/src/main/resources/mappers/groupCommentMapper.xml
+++ b/src/main/resources/mappers/groupCommentMapper.xml
@@ -44,6 +44,12 @@
    	select count(comment_id) from group_comment where group_id=#{groupId}
    </select>
    
+   <select id="currentCommentCount" resultType="int">
+   	<![CDATA[
+   		select count(comment_id) from group_comment where group_id=#{groupId} and comment_id<=#{commentId}
+   	]]>
+   </select>
+   
    <insert id="commentCreate">
    	insert into group_comment (group_id, user_id, comment_msg)
    	values (#{groupId}, #{userId}, #{commentMsg})

--- a/src/main/webapp/WEB-INF/static/js/group_list_read.js
+++ b/src/main/webapp/WEB-INF/static/js/group_list_read.js
@@ -11,6 +11,44 @@ function listBoard(page, perPageNum, searchType, keyword, startAge, endAge, cate
 	document.location.href=url;
 }
 
+function commentCount(groupId) {
+	return new Promise(resolve=> { 
+			let ret=0;
+			const xhr = new XMLHttpRequest();
+			xhr.open("POST", "/comment/count", true);
+			xhr.setRequestHeader(header, token);
+			xhr.setRequestHeader("Content-Type", "text/plain");
+			xhr.send(groupId);
+			xhr.onload = function () {
+				if(xhr.status == 200 || xhr.status == 201) {
+					ret=Number(xhr.responseText);
+					resolve(ret);
+				}
+			}
+		}
+	);
+}
+
+function currentCommentCount(groupId, commentId) {
+	return new Promise(resolve=> { 
+			let ret=0;
+			const data = { groupId : groupId , commentId : commentId};
+			const xhr = new XMLHttpRequest();
+			xhr.open("POST", "/comment/currentCount", true);
+			xhr.setRequestHeader(header, token);
+			xhr.setRequestHeader("Content-Type", "application/json");
+			xhr.send(JSON.stringify(data));
+			xhr.onload = function () {
+				if(xhr.status == 200 || xhr.status == 201) {
+					ret=Number(xhr.responseText);
+					resolve(ret);
+				}
+			}
+		}
+	);
+}
+
+
 var listApplyFlag=0;
 function applyGroup(groupId, userId, userName, listApplyChk) {
 	if(listApplyChk>0||listApplyFlag>0){
@@ -46,6 +84,7 @@ function applyGroup(groupId, userId, userName, listApplyChk) {
 	}
 }
 
+
 function commentCreate(groupId, userId) {
 	const commentMsg = document.getElementById("commentMsg").value;
 	const data = {
@@ -61,14 +100,14 @@ function commentCreate(groupId, userId) {
 		xhr.setRequestHeader(header, token);
 		xhr.setRequestHeader("Content-Type", "application/json");
 		xhr.send(JSON.stringify(data));
-		xhr.onload = function () {
+		xhr.onload = async function () {
 			if(xhr.status == 200 || xhr.status == 201) {
 				alert("댓글이 등록되었습니다. ");
 				document.getElementById("commentMsg").value="";
-				groupCommentCnt++;
-				console.log("Math.ceil(groupCommentCnt/10): "+Math.ceil(groupCommentCnt/10));
+				let groupCommentCnt= await commentCount(groupId);
 				listComment(Math.ceil(groupCommentCnt/10));
 			}
 		}
 	}
 }
+

--- a/src/main/webapp/WEB-INF/views/group_list_read.jsp
+++ b/src/main/webapp/WEB-INF/views/group_list_read.jsp
@@ -55,9 +55,6 @@
 		<button type="button" id="applyBtn" onclick="applyGroup(${GroupVO.groupId},'${UserVO.userId}','${UserVO.userName}',${listApplyChk})">신청하기</button>
 	</c:if>
 	<button type="button" id="listBtn" onclick="listBoard(${cri.page},${cri.perPageNum},'${cri.searchType}','${cri.keyword}','${cri.startAge}','${cri.endAge}','${cri.category}','${cri.area}')">목록으로</button>
-	<script>
-		var groupCommentCnt=${GroupVO.groupCommentCnt};
-	</script>
 	<div>	
 		<h2>댓글을 입력해주세요.</h2>
 		<label for="commentMsg">메세지를 작성해주세요</label>
@@ -69,10 +66,6 @@
 	<h2>댓글 목록입니다.</h2>
 	<div id="listComment"></div>
 	<script>
-	var category1 = "${cri.category}";
-	console.log(category1.substring(1, category1.length-1).split(",").map(v=> {
-		return "&category=" + v;
-	}).join());
 	const elementToken = document.querySelector('meta[name="_csrf"]');
 	const token = elementToken && elementToken.getAttribute("content");
 	const elementHeader = document.querySelector('meta[name="_csrf_header"]');
@@ -99,16 +92,16 @@
 			if(confirmed) {
 				const data={ commentId : commentId , groupId: ${GroupVO.groupId } };
 				const xhr = new XMLHttpRequest();
-				xhr.open("POST", "/comment/delete", true);
+				xhr.open("DELETE", "/comment/delete", true);
 				xhr.setRequestHeader(header, token);
 				xhr.setRequestHeader("Content-Type", "application/json");
 				xhr.send(JSON.stringify(data));
-				xhr.onload = function () {
+				xhr.onload = async function () {
 					if(xhr.status == 200 || xhr.status == 201) {
 						if(Number(xhr.responseText) == 1) {
 							alert("삭제되었습니다.")
-							groupCommentCnt--;
-							listComment(curPage);
+							let groupCommentCnt= await currentCommentCount(${GroupVO.groupId }, commentId);
+							listComment(Math.ceil(groupCommentCnt/10));
 						} else {
 							alert("에러가 발생했습니다. 잠시후 다시 시도해주세요.");
 						}
@@ -139,15 +132,16 @@
 				const commentMsg=document.getElementById("updateCommentMsg").value;	
 				const data={ commentId : commentId , commentMsg : commentMsg };
 				const xhr = new XMLHttpRequest();
-				xhr.open("POST", "/comment/update", true);
+				xhr.open("PUT", "/comment/update", true);
 				xhr.setRequestHeader(header, token);
 				xhr.setRequestHeader("Content-Type", "application/json");
 				xhr.send(JSON.stringify(data));
-				xhr.onload = function () {
+				xhr.onload = async function () {
 					if(xhr.status == 200 || xhr.status == 201) {
 						if(Number(xhr.responseText) == 1) {
 							alert("수정되었습니다.")
-							listComment(curPage);
+							let groupCommentCnt= await currentCommentCount(${GroupVO.groupId }, commentId);
+							listComment(Math.ceil(groupCommentCnt/10));
 						} else {
 							alert("에러가 발생했습니다. 잠시후 다시 시도해주세요.");
 						}


### PR DESCRIPTION
댓글의 총 갯수를 js 전역변수로 처리하면 여러명의 사용자가 동시에 이용할
경우 갯수를 반영하지 못한다. 따라서 수정, 삭제, 추가 시 해당 댓글이 몇
번째의 댓글인지 mapper를 이용해 DB에서 가져와 댓글 갯수를 갱신한다.
1. groupCommentMapper에 currentCommentCount 추가 (수정 ,삭제 시 이용)
2. 수정, 삭제시 js에서 동기로 처리하기 위해 async, await, promise 패턴을
이용하여 처리