### PR TITLE
탈퇴한 사용자에 대한 댓글 닉네임 처리

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/group_list_comment.js
+++ b/src/main/webapp/WEB-INF/static/js/group_list_comment.js
@@ -1,9 +1,12 @@
 function commentTemplate (userId, commentList) {
 	let commentSection = document.createElement("section");
 	for(let comment of commentList) {
-		let div = document.createElement("div"),
-			userName = comment.userVO.userName,
-			regDate = new Date(comment.regDate),
+		let div = document.createElement("div");
+			
+		let	userName="";
+		if(comment.userVO == undefined) userName="탈퇴한 사용자";
+		else userName = comment.userVO.userName;
+		let	regDate = new Date(comment.regDate),
 			modDate = new Date(comment.modDate),
 			regDateStr = regDate.format("yyyy/MM/dd HH:mm"),
 			modDateStr = modDate.format("yyyy/MM/dd HH:mm"),


### PR DESCRIPTION
탈퇴한 사용자는 id를 삭제하기 때문에 cannot read property 에러발생
cannot read property에 대한 에러해결