### PR TITLE
레이아웃에 따른 페이징처리 수정

### DIFF
--- a/src/main/java/ams/group/controller/GroupCommentController.java
+++ b/src/main/java/ams/group/controller/GroupCommentController.java
@@ -88,6 +88,7 @@ public class GroupCommentController {
 			cri.setPage(curPage);
 			System.out.println("get list.........");
 			PageMaker commentPageMaker = new PageMaker();
+			cri.setPerPageNum(10);
 			commentPageMaker.setCri(cri);
 			commentPageMaker.setTotalCount(service.commentCount(groupId));
 			List<GroupCommentVO> gcvoList= service.commentList(groupId, cri);

--- a/src/main/java/ams/group/domain/GroupCriteria.java
+++ b/src/main/java/ams/group/domain/GroupCriteria.java
@@ -6,7 +6,7 @@ public class GroupCriteria {
 	
 	public GroupCriteria() {
 		this.page=1;
-		this.perPageNum=10;
+		this.perPageNum=12;
 	}
 	
 	public void setPage(int page) {

--- a/src/main/resources/mappers/groupManageMapper.xml
+++ b/src/main/resources/mappers/groupManageMapper.xml
@@ -178,7 +178,7 @@
  		GA.USER_ID = U.USER_ID
  	WHERE GA.GROUP_ID=#{groupId}
  	ORDER BY GA.REG_DATE DESC
- 	LIMIT #{cri.pageStart}, 10
+ 	LIMIT #{cri.pageStart}, 12
  	]]>
    </select>
    


### PR DESCRIPTION
신청서와 그룹 찾기는 css를 이용하여 카드 형식으로 구성하기 위해 3x4 또는
4x3 배열로 보여주려고한다. 따라서 페이지당 보여줘야할 리스트의 수는
10개가 아닌 12개가 되어야한다. 그에 따른 mapper와 controller를 수정했다.